### PR TITLE
fix: return error response in chat route

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -224,6 +224,8 @@ export async function POST(request: Request) {
     if (error instanceof ChatSDKError) {
       return error.toResponse();
     }
+    console.error(error);
+    return new ChatSDKError('bad_request:api').toResponse();
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure chat POST route always returns a Response and logs non-ChatSDK errors
- provider leverages the `@ai-sdk/groq` client for Groq model integration

## Testing
- `pnpm lint` *(fails: Unable to resolve path to module 'recharts')*
- `pnpm test` *(HTML report served, 34 tests did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68a04615adf48326b4d6ae16eedd3fad