### PR TITLE
Handle unexpected errors in chat route

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -224,6 +224,9 @@ export async function POST(request: Request) {
     if (error instanceof ChatSDKError) {
       return error.toResponse();
     }
+
+    console.error(error);
+    return new Response('An unexpected error occurred', { status: 500 });
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure chat API handler always returns a Response, logging unexpected errors

## Testing
- `pnpm lint` *(fails: Unable to resolve path to module 'recharts')*
- `pnpm test` *(fails: 34 did not run; HTML report served)*

------
https://chatgpt.com/codex/tasks/task_e_68a04615adf48326b4d6ae16eedd3fad